### PR TITLE
Update API from CoinMarketCap and use CryptoCompare for historical

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,3 +133,6 @@ gem "turnout"
 
 # Admin
 gem 'rails_admin', '~> 1.3'
+
+# Requests
+gem "httparty"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,9 @@ GEM
       temple (>= 0.8.0)
       tilt
     hashie (3.6.0)
+    httparty (0.18.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -387,6 +390,7 @@ DEPENDENCIES
   figaro
   font-awesome-rails
   groupdate
+  httparty
   jbuilder (~> 2.5)
   jquery-datatables-rails (~> 3.4.0)
   jquery-minicolors-rails

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,49 +5,53 @@ module ApplicationHelper
     require 'net/http'
     require 'json'
     require "open-uri"
-    @url_API = 'https://api.coinmarketcap.com/v1/ticker/?limit=50'
-    @uri_API = URI(@url_API)
-    http_API = Net::HTTP.new(@uri_API.host, @uri_API.port)
-    http_API.use_ssl = true
-    http_API.verify_mode = OpenSSL::SSL::VERIFY_PEER
-    @response_API = Net::HTTP.get(@uri_API)
-    @coins = JSON.parse(@response_API) 
+    
+    url_API = 'https://pro-api.coinmarketcap.com/v1/cryptocurrency/listings/latest?start=1&limit=50'
+
+    request = headers = {
+      'Accepts': 'application/json',
+      'X-CMC_PRO_API_KEY': '19d34bbf-b9a6-4a40-885c-41431dacefee'
+    }
+
+    response = HTTParty.get(url_API, headers: headers)
+    @coins = response['data']
   end 
 
-  def get_monthly_from_API
-    require 'net/http'
-    require 'json'
-    require "open-uri"
-    @url_month = 'http://api.coindesk.com/v1/bpi/historical/close.json'
-    @uri_month = URI(@url_month)
-    http_month = Net::HTTP.new(@uri_month.host, @uri_month.port)
-    http_month.use_ssl = true
-    http_month.verify_mode = OpenSSL::SSL::VERIFY_PEER
-    @response_month = URI.parse(@url_month).read
-    @monthly = JSON.parse(@response_month)['bpi'] 
-    @monthly.store(Time.now().strftime('%Y-%m-%d'), @coins.first['price_usd'] )
-  end 
+  # def get_monthly_from_API
+  #   require 'net/http'
+  #   require 'json'
+  #   require "open-uri"
+  #   @url_month = 'http://api.coindesk.com/v1/bpi/historical/close.json'
+  #   @uri_month = URI(@url_month)
+  #   http_month = Net::HTTP.new(@uri_month.host, @uri_month.port)
+  #   http_month.use_ssl = true
+  #   http_month.verify_mode = OpenSSL::SSL::VERIFY_PEER
+  #   @response_month = URI.parse(@url_month).read
+  #   @monthly = JSON.parse(@response_month)['bpi'] 
+  #   @monthly.store(Time.now().strftime('%Y-%m-%d'), @coins.first['price_usd'] )
+  # end 
 
   def get_historical_from_API
     require 'net/http'
     require 'json'
     require "open-uri"
     today = Time.now.strftime('%Y-%m-%d')
-    @url_hist = 'https://api.coindesk.com/v1/bpi/historical/close.json?start=2015-09-01&end='+today
-    @uri_hist = URI(@url_hist)
-    http_hist = Net::HTTP.new(@uri_hist.host, @uri_hist.port)
-    http_hist.use_ssl = true
-    http_hist.verify_mode = OpenSSL::SSL::VERIFY_PEER
-    @response_hist = URI.parse(@url_hist).read
-    @historical = JSON.parse(@response_hist)['bpi'] 
+    
+    url_historical = 'https://min-api.cryptocompare.com/data/v2/histoday?fsym=BTC&tsym=USD&limit=300'
+
+    response = HTTParty.get(url_historical)
+
     # Array with data
-    @historical.store(Time.now().strftime('%Y-%m-%d'), @coins.first['price_usd'] )
-    # Obtain array of hashes 
-    key_value = @historical.map do |key, value| 
-      [key, value]
+    @historical = response['Data']['Data']
+    
+    # Obtain array of hashes like [{'date' => 'xxxxxxx', 'value' => 'yyyy'}]
+    @values_by_date = [] 
+    @historical.each do |record| 
+      @values_by_date << {
+                          'date' => DateTime.strptime(record['time'].to_s, '%s').strftime('%Y-%m-%d'), 
+                          'value' => record['close'] 
+                         }
     end
-    @array_of_hashes = [] 
-    key_value.each { |record| @array_of_hashes << {'date' => record[0], 'value' => record[1].to_i }} 
   end 
 
   def calculate_profit
@@ -69,7 +73,7 @@ module ApplicationHelper
               	# Save array with user id's
               	@array_ids.push(u.id)
                 # Calculate all the profits for all users
-                @profit_array[i] += ((c["price_usd"].to_d * crypto.amount_owned.to_d)-(crypto.cost_per.to_d * crypto.amount_owned.to_d)).round(2)
+                @profit_array[i] += ((c['quote']['USD']["price"].to_d * crypto.amount_owned.to_d)-(crypto.cost_per.to_d * crypto.amount_owned.to_d)).round(2)
               
               end
           end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -9,16 +9,16 @@ class Search < ApplicationRecord
     # @coins_filtered = @coins.select {|c| c["symbol"] == symbol.upcase } if symbol.present?
     if min_price.present? && max_price.present?
     	@coins_filtered = @coins.select {
-    		|c| (c["price_usd"].to_d > min_price.to_d && c["price_usd"].to_d < max_price.to_d)
+    		|c| (c['quote']['USD']['price'].to_d > min_price.to_d && c['quote']['USD']['price'].to_d < max_price.to_d)
     	} 
     else 
-    	@coins_filtered = @coins.select {|c| c["price_usd"].to_d > min_price.to_d } if min_price.present?
-    	@coins_filtered = @coins.select {|c| c["price_usd"].to_d < max_price.to_d } if max_price.present?
+    	@coins_filtered = @coins.select {|c| c['quote']['USD']['price'].to_d > min_price.to_d } if min_price.present?
+    	@coins_filtered = @coins.select {|c| c['quote']['USD']['price'].to_d < max_price.to_d } if max_price.present?
     end
 
-  	@coins_filtered = @coins.select {|c| c["percent_change_1h"].to_d.round(2) > percent_change_1h.to_d.round(2) } if percent_change_1h.present?
-  	@coins_filtered = @coins.select {|c| c["percent_change_24h"].to_d.round(2) > percent_change_24h.to_d.round(2) } if percent_change_24h.present?
-  	@coins_filtered = @coins.select {|c| c["percent_change_7d"].to_d.round(2) > percent_change_7d.to_d.round(2) } if percent_change_7d.present?
+  	@coins_filtered = @coins.select {|c| c['quote']['USD']['percent_change_1h'].to_d.round(2) > percent_change_1h.to_d.round(2) } if percent_change_1h.present?
+  	@coins_filtered = @coins.select {|c| c['quote']['USD']['percent_change_24h'].to_d.round(2) > percent_change_24h.to_d.round(2) } if percent_change_24h.present?
+  	@coins_filtered = @coins.select {|c| c['quote']['USD']['percent_change_7d'].to_d.round(2) > percent_change_7d.to_d.round(2) } if percent_change_7d.present?
 
     return @coins_filtered
 	end

--- a/app/views/cryptos/_form_edit.html.erb
+++ b/app/views/cryptos/_form_edit.html.erb
@@ -24,7 +24,7 @@
     
     <div class="field">
       <%= form.label "Current Price (U$D):", class: "col-md-6" %>
-      <span class= "col-md-2 text-center"> <%= @current_usd = current_coin(crypto.symbol)["price_usd"].to_d.round(5) %></span> 
+      <span class= "col-md-2 text-center"> <%= @current_usd = current_coin(crypto.symbol)['quote']['USD']['price'].to_d.round(5) %></span> 
       <input type="number" id="current-price" readonly="" value="<%= @current_usd %>" style="visibility: hidden;"/> 
       <div class="clearfix"></div> <br>
     </div>

--- a/app/views/cryptos/edit.html.erb
+++ b/app/views/cryptos/edit.html.erb
@@ -27,7 +27,7 @@
                             <div class="stat-icon dib">
                                 <% value_1h = [] %>	
                             	<% @coins.each do |c| %>
-                                	<% value_1h << c["percent_change_1h"].to_d %>
+                                	<% value_1h << c['quote']['USD']['percent_change_1h'].to_d %>
                                 <% end %>	
                                 <img src="/assets/<%=@coins[value_1h.each_with_index.max[1]]['symbol'].downcase%>" alt="" width="40px" title="<%=@coins[value_1h.each_with_index.max[1]]['name']%>">
                             </div>

--- a/app/views/cryptos/new.html.erb
+++ b/app/views/cryptos/new.html.erb
@@ -12,7 +12,7 @@
 						<strong><h3 class="pull-left"> Select the currency: </h3></strong><div class="clearfix"></div> <br>
 
 						<% array_names = @coins.map {|c| c['symbol']} %>
-						<% array_prices = @coins.map{|c| c['price_usd']} %>
+						<% array_prices = @coins.map{|c| c['quote']['USD']['price_usd']} %>
 				      	<% @user_coins = [] %>
 						<% @cryptos.each do |crypto| %>
 				      		<% if (crypto.user_id == current_user.id) && (crypto.amount_owned != 0) %>
@@ -20,7 +20,7 @@
 							<% end %>
 						<% end %>
 						<div class="col-md-5">
-							<%= select(:model, :coin, @coins.map {|c| [c['symbol'] + " | " + c['name'] + " | " + c['price_usd']]},{:prompt => 'Symbol | Name | Price'}, id:"new-order", onchange: "showForm('#{array_names}', '#{@user_coins}', '#{array_prices}')" , class: "custom-input custom-select") %> <br><br>
+							<%= select(:model, :coin, @coins.map {|c| [c['symbol'] + " | " + c['name'] + " | " + c['quote']['USD']['price'].to_s]},{:prompt => 'Symbol | Name | Price'}, id:"new-order", onchange: "showForm('#{array_names}', '#{@user_coins}', '#{array_prices}')" , class: "custom-input custom-select") %> <br><br>
 						</div>
 						<div id='form-new' style='visibility: hidden'>
 							<%= render 'form', crypto: @crypto %>

--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -122,8 +122,8 @@
                             <div class="card-body">
                                 <div class="progress-box progress-1">
                                     <h4 class="por-title">Current Price</h4>
-                                    <% @max_btc = @historical.values.take(@historical.values.size - 1).max %>
-                                    <% @price_btc = @coins.first['price_usd'].to_d.round(2) %>
+                                    <% @max_btc = @historical.map { |h| h['high'] }.max %>
+                                    <% @price_btc = @coins.first['quote']['USD']['price'].to_d.round(2) %>
                                     <% @percentage_max = 100*(@price_btc/@max_btc).to_d.round(2) %>
 
                                     <div class="por-txt"><strong><%= @price_btc %> </strong> (% <%= @percentage_max %>  from maximum value) </div>
@@ -133,18 +133,18 @@
                                 </div>
                                 <div class="progress-box progress-2">
                                     <h4 class="por-title">Volume (24h)</h4>
-                                    <div class="por-txt"><%=@coins.first['24h_volume_usd']%> (% <%= @percentage_volume = (100*(@coins.first['24h_volume_usd'].to_d.round(2))/(@coins.first['market_cap_usd'].to_d.round(2))).round(2)%> from total market cap) </div>
+                                    <div class="por-txt"><%=@coins.first['quote']['USD']['volume_24h']%> (% <%= @percentage_volume = (100*(@coins.first['quote']['USD']['volume_24h'].to_d.round(2))/(@coins.first['quote']['USD']['market_cap'].to_d.round(2))).round(2)%> from total market cap) </div>
                                     <div class="progress mb-2" style="height: 5px;">
                                         <div class="progress-bar bg-flat-color-2" role="progressbar" style="width: <%=@percentage_volume%>%;" aria-valuenow="<%=@percentage_volume%>" aria-valuemin="0" aria-valuemax="100"></div>
                                     </div>
                                 </div>
                                 <div class="progress-box progress-2">
                                     <h4 class="por-title">Percentage change (1 hr)</h4>
-                                    <div class="por-txt color-text"><%=@coins.first['percent_change_1h'] %>%</div>
+                                    <div class="por-txt color-text"><%=@coins.first['quote']['USD']['percent_change_1h'] %>%</div>
                                 </div>
                                 <div class="progress-box progress-2">
                                     <h4 class="por-title">Percentage change (24 hr)</h4>
-                                    <div class="por-txt color-text"> <%= @coins.first['percent_change_24h'] %>%</div>
+                                    <div class="por-txt color-text"> <%= @coins.first['quote']['USD']['percent_change_24h'] %>%</div>
                                 </div>
                             </div> <!-- /.card-body -->
                         </div>
@@ -212,7 +212,7 @@
     // Traffic Chart using chartist End
 
     // Chart BTC 
-    var data = [<%= raw @array_of_hashes.to_json %>];
+    var data = [<%= raw @values_by_date.to_json %>];
     var chartHistorical = AmCharts.makeChart("charthistorical", {
         "type": "serial",
         "theme": "light",

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -24,15 +24,15 @@
                             <% value_7d = [] %>
                             <% @coins.each do |c| %>
                               <tr>
-                                <td><%= c['rank'] %></td>
+                                <td><%= c['cmc_rank'] %></td>
                                 <td> <img src="/assets/<%=c['symbol'].downcase%>" width="17vw" alt="">
                                   <abbr title="<%= c["name"] %>"><%= link_to c["symbol"], "/lookup?q=#{c['symbol']}" %></abbr></td>
-                                <td> <%= c["price_usd"].to_d.round(5) %> </td>
-                                                        <% value_1h << c["percent_change_1h"]&.to_d || "0" %>
-                                <td class="color-text"> <%= c["percent_change_1h"] %> </td>
-                                                         <% value_24h << c["percent_change_24h"]&.to_d || "0" %>
-                                <td class="color-text"> <%= c["percent_change_24h"] %> </td>
-                                                        <% value_7d << c["percent_change_7d"]&.to_d || "0" %>
+                                <td> <%= c['quote']['USD']["price"].to_d.round(5) %> </td>
+                                                        <% value_1h << c['quote']['USD']["percent_change_1h"]&.to_d || "0" %>
+                                <td class="color-text"> <%= c['quote']['USD']["percent_change_1h"] %> </td>
+                                                         <% value_24h << c['quote']['USD']["percent_change_24h"]&.to_d || "0" %>
+                                <td class="color-text"> <%= c['quote']['USD']["percent_change_24h"] %> </td>
+                                                        <% value_7d << c['quote']['USD']["percent_change_7d"]&.to_d || "0" %>
                               </tr>
                             <% end %>
                           </tbody>

--- a/app/views/home/lookup.html.erb
+++ b/app/views/home/lookup.html.erb
@@ -46,19 +46,19 @@
 										<div class="col-md-6">
 											<p>		
 												<strong>Current Price:</strong>
-												<%= c["price_usd"].to_d.round(4) %> U$D<br>
+												<%= c['quote']['USD']['price'].to_d.round(4) %> U$D<br>
 											</p>
 											<p>
 												<strong>Variation (1h):</strong>
-												<span class="color-text"><%= c["percent_change_1h"] %> %</span>
+												<span class="color-text"><%= c['quote']['USD']['percent_change_1h'] %> %</span>
 											</p>
 											<p>
 												<strong>Variation (24h):</strong>
-												<span class="color-text"><%= c["percent_change_24h"] %> %</span>
+												<span class="color-text"><%= c['quote']['USD']['percent_change_24h'] %> %</span>
 											</p>
 											<p>
 												<strong>Variation (7d):</strong>
-												<span class="color-text"><%= c["percent_change_7d"] %> %</span>
+												<span class="color-text"><%= c['quote']['USD']['percent_change_7d'] %> %</span>
 											</p>
 										</div>
 									<% end %>

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -44,15 +44,15 @@
                                             <% if (crypto.symbol == c["symbol"]) %>
                                               <% @current_name << c["symbol"].upcase %>
                                               <td> <%= link_to c["name"], edit_crypto_path(crypto.id) %> </td>
-                                              <td> $<%= c["price_usd"].to_d.round(4) %> </td>
-                                              <td  class="color-text"> <%= c["percent_change_1h"] %></td>
-                                              <td class="color-text"> <%= c["percent_change_24h"] %></td>
-                                              <td class="color-text"> <%= c["percent_change_7d"] %></td>
+                                              <td> $<%= c['quote']['USD']['price'].to_d.round(4) %> </td>
+                                              <td  class="color-text"> <%= c['quote']['USD']['percent_change_1h'] %></td>
+                                              <td class="color-text"> <%= c['quote']['USD']['percent_change_24h'] %></td>
+                                              <td class="color-text"> <%= c['quote']['USD']['percent_change_7d'] %></td>
                                               <td> <%= crypto.amount_owned.to_d %> </td>
                                               <td> <%= number_to_currency(crypto.cost_per) %></td>
-                                              <% @current_amount << (c["price_usd"].to_d * crypto.amount_owned.to_d).round(2) %>
+                                              <% @current_amount << (c['quote']['USD']['price'].to_d * crypto.amount_owned.to_d).round(2) %>
                                               <td> $ <%= @current_amount.last %> </td>
-                                              <td> <span class="color-text"> <%= @balance = ((c["price_usd"].to_d * crypto.amount_owned.to_d)-(crypto.cost_per.to_d * crypto.amount_owned.to_d)).round(2) %> </span> </td>
+                                              <td> <span class="color-text"> <%= @balance = ((c['quote']['USD']['price'].to_d * crypto.amount_owned.to_d)-(crypto.cost_per.to_d * crypto.amount_owned.to_d)).round(2) %> </span> </td>
                                             <% end %>
                                           <% end %>
                                           <td> <%= link_to 'New Order', edit_crypto_path(crypto) %></td>

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -22,19 +22,19 @@
 					</p>
 					<p>		
 						<strong>Current Price:</strong>
-						U$D <%= c["price_usd"] %> <br>
+						U$D <%= c['quote']['USD']['price'] %> <br>
 					</p>
 					<p>
 						<strong>Variation (1h):</strong>
-						<%= c["percent_change_1h"] %> %
+						<%= c['quote']['USD']['percent_change_1h'] %> %
 					</p>
 					<p>
 						<strong>Variation (24h):</strong>
-						<%= c["percent_change_24h"] %> %
+						<%= c['quote']['USD']['percent_change_24h'] %> %
 					</p>
 					<p>
 						<strong>Variation (7 days):</strong>
-						<%= c["percent_change_7d"] %> %
+						<%= c['quote']['USD']['percent_change_7d'] %> %
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
CoinMarket Updated its API https://coinmarketcap.com/api/documentation/v1/
and historical prices are not available for free anymore